### PR TITLE
this is a temporary fix to update the shpc parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ If you are interested in contributing to Binoc, we love pull requests! If you've
 3. `go build binoc.go` <-- will build binoc into an executable on your machine.
 
 
+You can then test binoc on a repository by way of exporting environment variables for the
+command. For example:
+
+```bash
+INPUT_REPO_PATH=/path/to/test/ INPUT_PARSERS_LOADED=shpc INPUT_GENERAL_ACTION=false INPUT_GIT_TOKEN=ghp_xxxx go run binoc.go
+```
+
 ## License
 
 Copyright 2021 Alec Scott & Autamus <hi@alecbcs.com>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can then test binoc on a repository by way of exporting environment variable
 command. For example:
 
 ```bash
-INPUT_REPO_PATH=/path/to/test/ INPUT_PARSERS_LOADED=shpc INPUT_GENERAL_ACTION=false INPUT_GIT_TOKEN=ghp_xxxx go run binoc.go
+BINOC_REPO_PATH=/path/to/test/ BINOC_PARSERS_LOADED=shpc BINOC_GIT_TOKEN=ghp_xxxx go run binoc.go
 ```
 
 ## License

--- a/parsers/shpc.go
+++ b/parsers/shpc.go
@@ -161,7 +161,13 @@ func (s *ContainerSpec) CheckUpdate() (outOfDate bool, output *results.Result) {
 		if docker {
 			new = version.Version{result.Version.String() + "@" + result.Name}
 		} else {
-			new = version.Version{result.Version.String() + "@" + s.Name}
+			new = version.Version{latestKey + "@" + result.Version.String()}
+
+			// A gh release expects the "tag" as the recipe extension
+			result.Name = result.Version.String()
+
+			// And the digest as the release version
+			result.Version = version.NewVersion(latestKey)
 		}
 		if latest.String() != new.String() {
 			outOfDate = true


### PR DESCRIPTION
The gh:// parser treats a recipe extension (e.g., salad) as a tag, and then the release from the GitHub version as the digest. This sort of assumes that every release has the same tags, or the tags that are desired are represented in the repository. Afaik Binoc/cuppa does not do any custom parsing of the artifacts to discover tags. So this PR fixes a bug that the release versions are being used as tags, and the name of the repository as the digest. For example, the current parser does:

```yaml
latest:
    0.0.12: singularityhub/singularity-deploy
```
But it should be:

```yaml
latest:
    salad: 0.0.12
```

So this fixes that. If binoc doesn't discover the recipe names from the artifact names, I suspect in the future we could have problems if a tag is removed (meaning a Singularity.<tag> file being built is deleted).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>