### PR TITLE
Adding missing features entry to shpc

### DIFF
--- a/parsers/shpc.go
+++ b/parsers/shpc.go
@@ -87,6 +87,7 @@ type ContainerSpec struct {
 	Filter        []string          `yaml:"filter,omitempty"`
 	Aliases       map[string]string `yaml:"-"`
 	AliasesStruct []Alias           `yaml:"-"`
+	Features      map[string]bool   `yaml:"features,omitempty"`
 }
 
 type AliasMap struct {


### PR DESCRIPTION
Currently, recipes with features are truncated (the features are removed) because we do not represent them here! I am hoping this fixes it! Here is an example of the bug (that also shows the structure):

https://github.com/singularityhub/singularity-hpc/pull/419/files#diff-e430aec0977d84adbe1ce4c461262a4b50f5eb641578296e2e75cd7b152f56deL13

Signed-off-by: vsoch <vsoch@users.noreply.github.com>