### PR TITLE
fixing bug with singularity/docker parsers

### DIFF
--- a/parsers/shpc.go
+++ b/parsers/shpc.go
@@ -76,20 +76,18 @@ func (s SHPC) Encode(pkg Package) (result string, err error) {
 
 // ContainerSpec is a wrapper struct for a container.yaml
 type ContainerSpec struct {
-	Name            string            `yaml:"name,omitempty"`
-	Docker          string            `yaml:"docker,omitempty"`
-	Gh              string            `yaml:"gh,omitempty"`
-	Url             string            `yaml:"url,omitempty"`
-	Maintainer      string            `yaml:"maintainer"`
-	Description     string            `yaml:"description"`
-	Latest          map[string]string `yaml:"latest"`
-	Versions        map[string]string `yaml:"tags"`
-	Filter          []string          `yaml:"filter,omitempty"`
-	Aliases         map[string]string `yaml:"-"`
-	AliasesStruct   []Alias           `yaml:"-"`
-	Features        map[string]bool   `yaml:"features,omitempty"`
-	SingularityOpts string            `yaml:"singularity_options,omitempty"`
-	DockerOpts      string            `yaml:"docker_options,omitempty"`
+	Name          string            `yaml:"name,omitempty"`
+	Docker        string            `yaml:"docker,omitempty"`
+	Gh            string            `yaml:"gh,omitempty"`
+	Url           string            `yaml:"url,omitempty"`
+	Maintainer    string            `yaml:"maintainer"`
+	Description   string            `yaml:"description"`
+	Latest        map[string]string `yaml:"latest"`
+	Versions      map[string]string `yaml:"tags"`
+	Filter        []string          `yaml:"filter,omitempty"`
+	Aliases       map[string]string `yaml:"-"`
+	AliasesStruct []Alias           `yaml:"-"`
+	Features      map[string]bool   `yaml:"features,omitempty"`
 }
 
 type AliasMap struct {
@@ -101,9 +99,11 @@ type AliasStruct struct {
 }
 
 type Alias struct {
-	Name    string `yaml:"name,omitempty"`
-	Command string `yaml:"command,omitempty"`
-	Options string `yaml:"options,omitempty"`
+	Name            string `yaml:"name,omitempty"`
+	Command         string `yaml:"command,omitempty"`
+	Options         string `yaml:"options,omitempty"`
+	SingularityOpts string `yaml:"singularity_options,omitempty"`
+	DockerOpts      string `yaml:"docker_options,omitempty"`
 }
 
 // AddVersion adds a tagged version to a container.


### PR DESCRIPTION
This is embarrassing, but I put the Singularity/Docker options in the wrong place! They should be under an alias. And I'm leaving the old "options" attribute to support any recipes that haven't been converted - it shouldn't hurt with omitempty.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>