### PR TITLE
Test adding oras command for shpc

### DIFF
--- a/parsers/shpc.go
+++ b/parsers/shpc.go
@@ -77,6 +77,7 @@ func (s SHPC) Encode(pkg Package) (result string, err error) {
 // ContainerSpec is a wrapper struct for a container.yaml
 type ContainerSpec struct {
 	Name            string            `yaml:"name,omitempty"`
+	Oras            string            `yaml:"oras,omitempty"`
 	Docker          string            `yaml:"docker,omitempty"`
 	Gh              string            `yaml:"gh,omitempty"`
 	Url             string            `yaml:"url,omitempty"`
@@ -139,7 +140,9 @@ func (s *ContainerSpec) GetAllVersions() (result []results.Result) {
 
 // GetURL returns the location of a container for Lookout
 func (s *ContainerSpec) GetURL() (result string) {
-	if s.Docker != "" {
+
+	// Docker and oras are both provided via OCI registries
+	if s.Docker != "" || s.Oras != "" {
 		result = "docker://" + s.Docker
 		if len(s.Filter) > 0 {
 			result = result + ":" + s.Filter[0]


### PR DESCRIPTION
@alecbcs SHPC recently had the oras directive added to the container.yaml, meaning that a user can pull a singularity SIF directly from an OCI registry! Since it's an OCI registry entry and just a different artifact type, I'm thinking we can first try parsing it the same as docker. If that does not work we can skip for now. Should I use this branch to test shpc and verify if this works or not (I think this would be a good idea over blindly merging it!)

Signed-off-by: vsoch <vsoch@users.noreply.github.com>